### PR TITLE
Remove extra text codecheck yml reference

### DIFF
--- a/codecheck.yml
+++ b/codecheck.yml
@@ -11,9 +11,7 @@ paper:
       ORCID: https://orcid.org/0000-0001-7972-563
     - name: Manuel Spitschan
       ORCID: https://orcid.org/0000-0002-8572-9268
-  reference: >
-    Scientific Reports, in press (DOI 10.1038/s41598-023-48241-y)
-    https://www.researchsquare.com/article/rs-2587424/v1
+  reference: https://www.researchsquare.com/article/rs-2587424/v1
 
 manifest:
   - file: Figures/Figure2-screenshot.png

--- a/codecheck.yml
+++ b/codecheck.yml
@@ -11,7 +11,7 @@ paper:
       ORCID: https://orcid.org/0000-0001-7972-563
     - name: Manuel Spitschan
       ORCID: https://orcid.org/0000-0002-8572-9268
-  reference: https://www.researchsquare.com/article/rs-2587424/v1
+  reference: https://doi.org/10.21203/rs.3.rs-2587424/v1
 
 manifest:
   - file: Figures/Figure2-screenshot.png


### PR DESCRIPTION
In the `codecheck.yml` there was extra text in paper reference. I removed this extra text. 
Refer to comments in another PR about this: [link](https://github.com/codecheckers/register/issues/88#issuecomment-2343273428)

@nuest could you review and merge if you're okay with the changes. I do not have permission to merge.